### PR TITLE
WDP200702-32

### DIFF
--- a/src/components/features/Brands/Brands.js
+++ b/src/components/features/Brands/Brands.js
@@ -43,7 +43,8 @@ class Brands extends React.Component {
     const { brands, device } = this.props;
     const { activePage } = this.state;
 
-    const elementsPerDevice = device === 'mobile' ? 2 : device === 'tablet' ? 3 : 6;
+    const elementsPerDevice =
+      device === 'smobile' ? 1 : device === 'mobile' ? 2 : device === 'tablet' ? 3 : 6;
 
     const pagesCount = Math.ceil(brands.length / elementsPerDevice);
 

--- a/src/components/features/Brands/Brands.module.scss
+++ b/src/components/features/Brands/Brands.module.scss
@@ -12,7 +12,7 @@
     justify-content: space-between;
 
     .control {
-      height: 92px;
+      height: 90px;
       width: 30px;
       background: $brands-control-buton;
       display: flex;
@@ -37,6 +37,7 @@
     .logoBox {
       width: 90%;
       margin: 0 auto;
+      height: 90px;
     }
   }
 
@@ -51,6 +52,16 @@
 
       img {
         width: 100%;
+      }
+    }
+  }
+}
+
+@media (max-width: $mobile-breakpoint) {
+  .root {
+    .wrapper {
+      .logoBox {
+        width: 80%;
       }
     }
   }

--- a/src/redux/deviceRedux.js
+++ b/src/redux/deviceRedux.js
@@ -18,13 +18,18 @@ export default function reducer(statePart = [], action = {}) {
       const breakpoints = {
         tablet: 992,
         mobile: 768,
+        smobile: 375,
       };
 
       if (action.payload >= breakpoints.tablet) {
         return 'desktop';
       } else if (action.payload >= breakpoints.mobile) {
         return 'tablet';
-      } else return 'mobile';
+      } else if (action.payload >= breakpoints.smobile) {
+        return 'mobile';
+      } else {
+        return 'smobile';
+      }
     }
     default:
       return statePart;


### PR DESCRIPTION
CEL:
Nadanie sekcji `Brands` charakteru responsywnego.

ZMIANY:
1. `deviceRedux.js`
-Nadanie nowego breakpointu "smobile" dla mniejszych telefonów - pierwotnie dwa kafelki z markami przy małym ekranie nie wyglądały najlepiej - teraz wyświetla się jeden dla urządzeń o szerokości mniejszej niż 375 px
2.`Brands.js`
-Nadanie nowego warunku w zmiennej `elementsPerDevice` - rozszerzając całą instrukcję o urządzenia "smobile"
3.`Brands.module.scss`
-Zmiana wysokości przycisków i elementu o klasie `logoBox` - przy zmianie wymiarów ekranu, wysokości nie szły ze sobą w linii.
-Zmiana szerokości elementu o klasie `logoBox` dla urządzeń o maksymalnej szerokości ekranu określonej w `settings.scss` jako `mobile-breakpoint` w celu zapobiegnięcia zwężania się przycisków.

UWAGI:
-Wprowadzenie nowego rodzaju urządzenia w `deviceRedux.js` powoduje zmianę responsywnego wyglądu dla komponentu `NewFurniture` - potrzeba zmiany instrukcji warunkowej w tym komponencie (nowy task) lub rezygnacja z wersji urządzeń "smobile"

JIRA:
https://projects.kodilla.com/browse/WDP200702-32